### PR TITLE
fix(schema.prisma): Remove `shadowDatabaseUrl`

### DIFF
--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -5,7 +5,7 @@ datasource db {
   provider          = "postgresql"
   url               = env("POSTGRES_PRISMA_URL") // uses connection pooling
   directUrl         = env("POSTGRES_URL_NON_POOLING") // uses a direct connection
-  shadowDatabaseUrl = env("POSTGRES_URL_NON_POOLING") // used for migrations
+
 }
 
 generator client {


### PR DESCRIPTION
`shadowDatabaseUrl` is no longer required for Vercel Postgres and may cause issues when set to the same value as `directUrl`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated database configuration settings for improved performance and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->